### PR TITLE
DEBUG版本：解决了一些实现的bug

### DIFF
--- a/luckysheet_obj/apps/lucky_sheet/views.py
+++ b/luckysheet_obj/apps/lucky_sheet/views.py
@@ -71,8 +71,9 @@ class LuckySheetSaveDb(View):
         return HttpResponse({})
 
     def post(self, request):
-        gridKey = str(uuid.uuid1())
+        #gridKey = str(uuid.uuid1())
         luckysheet_data = json.loads(request.POST.get("data"))
+        gridKey = luckysheet_data.get('gridKey', str(uuid.uuid1()))
         luckysheet_data['allowUpdate'] = True
         luckysheet_data['updateUrl'] = settings.WSS_UPDATE_URL
         luckysheet_data['loadUrl'] = settings.WSS_LOAD_URL

--- a/luckysheet_obj/apps/lucky_sheet/websocket_server.py
+++ b/luckysheet_obj/apps/lucky_sheet/websocket_server.py
@@ -49,17 +49,26 @@ def send_websocket_message(userid, grid_key, res):
     for _client in list(WEB_SOCKET_CLIENT.keys()):
         # 把自己的操作去掉，只给别的客户端更新操作
         # 如果没有gridkey，则默认给所有没有gridkey的客户端同步消息，主要是首页演示使用
-        if _client != userid:
-            logger.info("sed to %s" % _client)
-            request = WEB_SOCKET_CLIENT.get(_client).get("userid")
+        #if _client != userid:
+        #    logger.info("sed to %s" % _client)
+        #    request = WEB_SOCKET_CLIENT.get(_client).get("userid")
             # print("the web socket receive message message is: ", new_msg)
-            request.send(json.dumps(new_msg))  # 发送消息到客户端
+        #    request.send(json.dumps(new_msg))  # 发送消息到客户端
 
         # 如果有gridkey，则根据gridkey返回更新值，实际应用场景使用
-        __gridkey = WEB_SOCKET_CLIENT.get(_client).get("grid_key", "")
-        if not __gridkey:
-            request = WEB_SOCKET_CLIENT.get(_client).get("userid")
-            request.send(json.dumps(new_msg))  # 发送消息到客户端
+        #__gridkey = WEB_SOCKET_CLIENT.get(_client).get("grid_key", "")
+        #if not __gridkey:
+        #    request = WEB_SOCKET_CLIENT.get(_client).get("userid")
+        #    request.send(json.dumps(new_msg))  # 发送消息到客户端
+        logger.info("user:" + _client)
+        if _client != userid:
+            __gridkey = WEB_SOCKET_CLIENT.get(_client).get("grid_key", "")
+            logger.info("grid_key: %s" % __gridkey)
+            if (not __gridkey) or (__gridkey == grid_key):
+                logger.info("sed to %s" %  _client)
+                request = WEB_SOCKET_CLIENT.get(_client).get("userid")
+                # print("the web socket receive message message is: ", new_msg)
+                request.send(json.dumps(new_msg))  # 发送消息到客户端
 
 
 @accept_websocket

--- a/luckysheet_obj/apps/lucky_sheet/websocket_server.py
+++ b/luckysheet_obj/apps/lucky_sheet/websocket_server.py
@@ -64,7 +64,8 @@ def send_websocket_message(userid, grid_key, res):
 
 @accept_websocket
 def websocket_update_url(request):
-    userid = str(uuid.uuid1())
+    #userid = str(uuid.uuid1())
+    userid = str(request.user) + "@" + request.META.get("REMOTE_ADDR", "unknownIP")
     grid_key = request.GET.get("g", "")
     # 每个客户端请求进来的时候，只会走一次这个流程，因此在这里面设置一个uuid
     if request.is_websocket():

--- a/luckysheet_obj/apps/lucky_sheet/websocket_server.py
+++ b/luckysheet_obj/apps/lucky_sheet/websocket_server.py
@@ -19,6 +19,7 @@ from lucky_sheet.log import logger
 from lucky_sheet import luckysheet_update
 import urllib.parse
 import zlib
+import lucky_sheet.jvm_tool as jvm_tool
 
 WEB_SOCKET_CLIENT = dict()
 
@@ -91,12 +92,12 @@ def websocket_update_url(request):
                 logger.info(message)
                 WEB_SOCKET_CLIENT[userid]["userid"].send(json.dumps(res))
             else:
-                # jpy = jvm_tool.jpython_obj
-                # res = jpy.unCompressURI(message)
-                destr = zlib.decompress(
-                    bytes(message, 'ISO-8859-1'), zlib.MAX_WBITS | 16)
-                result = urllib.parse.unquote_to_bytes(destr)
-                res = json.loads(str(result, 'utf-8'))
+                jpy = jvm_tool.jpython_obj
+                result = jpy.unCompressURI(message)
+                #destr = zlib.decompress(
+                #    bytes(message, 'ISO-8859-1'), zlib.MAX_WBITS | 16)
+                #result = urllib.parse.unquote_to_bytes(destr)
+                res = json.loads(str(result))
                 logger.info(res)
                 send_websocket_message(userid, grid_key, res)
 

--- a/luckysheet_obj/apps/lucky_sheet/websocket_server.py
+++ b/luckysheet_obj/apps/lucky_sheet/websocket_server.py
@@ -65,7 +65,7 @@ def send_websocket_message(userid, grid_key, res):
 @accept_websocket
 def websocket_update_url(request):
     #userid = str(uuid.uuid1())
-    userid = str(request.user) + "@" + request.META.get("REMOTE_ADDR", "unknownIP")
+    userid = str(request.user) + "-" + request.META.get("REMOTE_ADDR", "unknownIP")
     grid_key = request.GET.get("g", "")
     # 每个客户端请求进来的时候，只会走一次这个流程，因此在这里面设置一个uuid
     if request.is_websocket():

--- a/luckysheet_obj/newip.sh
+++ b/luckysheet_obj/newip.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "new ip is: "$1
+
+#echo "old file:"
+sed -n '/http:\/\/.*:3000/p' ./apps/lucky_sheet/templates/*
+
+echo "after switch"
+#注意：单引号会失效。
+sed -i "s/http:\/\/.*:3000/http:\/\/$1:3000/g" ./apps/lucky_sheet/templates/*
+#sed -n '/http:\/\/.*:3000/p' ./apps/lucky_sheet/templates/*
+
+SETTING="./luckysheet_obj/settings.py"
+
+vim $SETTING << EOF
+:/ALLOWED_HOSTS
+AxA, '$1']
+
+:wq
+EOF
+
+
+sed -i "s/http:\/\/.*:.*\/luckysheetloadurl/http:\/\/$1:8080\/luckysheetloadurl/g" $SETTING
+sed -i "s/ws:\/\/.*:.*\/luckysheetupdateurl/ws:\/\/$1:8080\/luckysheetupdateurl/g" $SETTING
+
+#redis可能不用切
+#sed -i "s/redis:\/\/.*:6379/redis:\/\/$1:6379/g" $SETTING
+#sed -i "s/'HOST': '.*'/'HOST': '$1'/g" $SETTING


### PR DESCRIPTION
1. 增加了个newip.sh，方便在不同ip下切换。注意：第一次切换，需要在settings.py中将ALLOWED_HOST中的多余“，”删除。
2. 移除之前的python解压相关内容，恢复原有实现。python解压的方式存在bug，无法正常运行。 
3. 更改userid与gridkey相关实现。前者使得SaveDb后即使重入websocket，也保持userid一致不变，消除产生多userid--对一个客户端的bug；后者使得SaveDb后，依旧保持同一个gridKey，便于实现实际协同。
4. 修改部分发送逻辑。